### PR TITLE
Fix for #6: Swagger validation errors: additional properties - shape, documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "js-yaml": "^3.8.2",
-    "openapi_optimise": "latest",
+    "openapi_optimise": "1.0.4",
     "recursive-readdir": "^2.1.0",
     "yargs": "latest"
   },


### PR DESCRIPTION
Fixes #6 
The root cause is a breaking change made to the `recurse` function used
from `openapi_optimise`. This fixes the version of `openapi_optimize` to allow only
version 1.0.4, the latest working version.

You may also want to commit a package-lock.json file to avoid similar issues later, but I did not add that to this commit.
