### PR TITLE
Disambiguate AWS paths with fragment parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -803,9 +803,9 @@ module.exports = {
             for (var p in src.operations) {
                 var op = src.operations[p];
 
-                var action = {
-                    deprecated: !!op.deprecated
-                };
+                var action = { };
+
+                if (op.deprecated) action.deprecated = true;
 
                 if (op.http) {
                     if (s.schemes.indexOf('http')<0) {

--- a/index.js
+++ b/index.js
@@ -779,20 +779,20 @@ module.exports = {
             sec.hmac = [];
             s.security.push(sec);
 
-            var protocol = src.metadata.protocol;
+            const protocol = src.metadata.protocol;
 
-            if ((protocol == 'query') && (src.metadata.xmlNamespace)) {
-                protocol = 'xml';
-            }
-            if ((protocol == 'query') && (src.metadata.jsonVersion)) {
-                protocol = 'json';
-            }
-
-            if ((protocol == 'rest-json') || (protocol == 'json')) {
+            if (
+                protocol == 'rest-json' ||
+                protocol == 'json' ||
+                (protocol == 'query' && src.metadata.jsonVersion)
+            ) {
                 s.consumes.push('application/json');
                 s.produces.push('application/json');
             }
-            if (protocol == 'rest-xml') {
+            if (
+                protocol == 'rest-xml' ||
+                (protocol == 'query' && src.metadata.xmlNamespace)
+            ) {
                 s.consumes.push('text/xml');
                 s.produces.push('text/xml');
             }
@@ -915,7 +915,7 @@ module.exports = {
 
                 // Work out a unique path identifier sufficient to look up the relevant
                 // path given a full request, for routing etc.
-                switch (src.metadata.protocol) {
+                switch (protocol) {
                     case 'rest-xml':
                     case 'rest-json':
                         // Identified by specific requestUri params.
@@ -950,7 +950,7 @@ module.exports = {
                         break;
 
                     default:
-                        throw new Error('Unknown protocol: ' + src.metadata.protocol);
+                        throw new Error('Unknown protocol: ' + protocol);
                 }
 
                 // Before adding the operation, we need to confirm the URL+method don't conflict

--- a/index.js
+++ b/index.js
@@ -957,7 +957,7 @@ module.exports = {
                 if (s.paths[url]) {
                     const conflictingAction = s.paths[url][method];
                     if (conflictingAction) {
-                        const deprecatedUrl = url + (url.indexOf('#') > -1 ? '&' : '#') + 'deprecated';
+                        const deprecatedUrl = url + (url.indexOf('#') > -1 ? '&' : '#') + 'deprecated!';
 
                         if (conflictingAction.deprecated) {
                             // We're a new version of a deprecated action. Move the deprecated version,

--- a/index.js
+++ b/index.js
@@ -734,7 +734,9 @@ module.exports = {
                     action.operationId = p; // TODO not handled is 'alias', add as a vendor extension if necessary
                     action.description = (op.documentation ? clean(op.documentation) : '');
                     if (op.documentationUrl) {
-                        action.description += '<p>'+op.documentationUrl+'</p>';
+                        action.externalDocs = {
+                            url: op.documentationUrl
+                        };
                     }
                     action.responses = {};
                     var success = {};

--- a/index.js
+++ b/index.js
@@ -839,6 +839,18 @@ module.exports = {
                     url = url.replace('?', '#');
                 }
 
+                if (op.input && op.input.shape) {
+                    // Add any other required query params to the URL fragment too
+                    const paramShape = src.shapes[op.input.shape];
+                    const requiredQueryParamNames = _.filter(paramShape.members, (member, memberName) =>
+                        member.location === 'querystring' && _.includes(paramShape.required, memberName)
+                    ).map((param) => param.locationName);
+
+                    if (requiredQueryParamNames.length > 0) {
+                        url += (url.indexOf('#') > -1 ? '&' : '#') + requiredQueryParamNames.join('&');
+                    }
+                }
+
                 // Work out a unique path identifier sufficient to look up the relevant
                 // path given a full request, for routing etc.
                 switch (src.metadata.protocol) {


### PR DESCRIPTION
This fixes https://github.com/APIs-guru/aws2openapi/issues/2.

This PR is pretty complicated and does a few things:

* Changes the fragment used in AWS paths to make the paths routable by examining parameters
* Changes the parameter parsing and output so we can find the relevant parameters
* Adds deprecation info for operations
* Adds proper `externalDocs` links to operation docs, where available (only S3)
* Includes the correct produces/consumes for query specs using XML (previously this was blank)

It's in separate commits, which should help with reviewing!

## Path fragments

Right now, all ambiguous paths are named with `#{operationId}`, e.g. `/{bucket}#DeleteBucket` for the S3 delete bucket operation. In this format, it's impossible to look at a given request and automatically tell OpenAPI operation it's performing.

This PR changes this so that every path includes a fragment that specifies the required parameters of an operation, which can be used to match it when the path is ambiguous. For example, `/{Bucket}/{Key}#select&select-type=2`, which matches requests where a `select` parameter is present (with any or an empty value) and the `select-type` parameter is set to `2`. These can overlap, so the most specific matching path should be used.

Fragment parameters may be query parameters, or header parameters. The names match the name of the parameter in the corresponding operation, regardless of location.

In some specs, near-identical endpoints are defined repeatedly, for the current & deprecated versions of the same operation. In that case, we add a `deprecated!` parameter to the fragment for the deprecated version, so they don't conflict. That means routing etc will always find the current one, but anybody sending requests, or browsing the spec can still see & use both.

Some example paths from the generated S3 spec:

* `PUT /{Bucket}/{Key}` - adds an object to a bucket
* `PUT /{Bucket}/{Key}#x-amz-copy-source` - copies an object into a bucket, specifying the source bucket in the `x-amz-copy-source` header param
* `GET /{Bucket}#lifecycle` - get the lifecycle of a bucket
* `GET /{Bucket}#lifecycle&deprecated!` - a now-deprecated & replaced endpoint for getting the lifecycle of a bucket

## Param parsing

This isn't enough. The current implementation doesn't actually create parameters for most parameters in the AWS data, so we can't easily tell whether a given parameter in a fragment is a header or query parameter, or anything else about it.

Instead, right now every operation with parameters is given [a single 'body' parameter](https://github.com/APIs-guru/aws2openapi/blob/79a761c/index.js#L725-L747), which includes every other specified parameter. For 'json' protocol services that's broadly correct, but it's not correct for any others, which are the vast majority.

This PR implements _most_ of the per-protocol logic to define more-or-less correct parameters for each operation. This makes fragment routing possible, gives us better parameter data (including param descriptions etc), and makes the specs much more accurate.

This is close, but doesn't work 100%. For all primitive typed params, I believe it's correct. For object & array params, it simplifies things drastically. Nested object parameters are definitely not included, and I suspect others aren't quite right. Nonetheless, it's much closer than the current state. To take this further, I think we'd want to go to OpenAPI 3 (so we can use full JSON schema for params), and refactor the overall structure a fair bit (in short: I'd build the tree top-down, rather than trying to change it in place as in transformShape, which is super hard as it misses a lot of necessary context at each step).

A params comparison, to make this clearer:

*  An RDS endpoint with the current spec:

![Screenshot from 2019-03-14 14-26-10](https://user-images.githubusercontent.com/1526883/54360440-25b87e80-4665-11e9-8ba7-a5be2ea1c9bf.png)

* An RDS endpoint with the new spec:

![Screenshot from 2019-03-14 14-27-11](https://user-images.githubusercontent.com/1526883/54360498-4680d400-4665-11e9-89a4-35f6df8c237d.png)

* The actual docs: https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_AddRoleToDBInstance.html

Should be easy to run and check the diff locally, but to save time here's a couple of examples:
[AWS-examples.zip](https://github.com/APIs-guru/aws2openapi/files/2966605/AWS-examples.zip)
