### PR TITLE
Use the official docs for external docs, not the marketing page

### DIFF
--- a/index.js
+++ b/index.js
@@ -571,10 +571,15 @@ module.exports = {
             if (prefEntry) preferred = (prefEntry.preferred == src.metadata.apiVersion);
             s.info['x-preferred'] = preferred;
 
-            s.externalDocs = {};
-            s.externalDocs.description = 'Amazon Web Services documentation';
             var epp = src.metadata.endpointPrefix.split('.');
-            s.externalDocs.url = 'https://aws.amazon.com/'+epp[epp.length-1]+'/';
+
+            s.externalDocs = {
+                description: 'Amazon Web Services documentation',
+                // This is a best guess. Mostly correct, but not always.
+                // In future, it might be good to test it for 404s, and try
+                // some other possible URL formats too as a backup.
+                url: 'https://docs.aws.amazon.com/'+epp[epp.length-1]+'/'
+            };
             s.host = src.metadata.endpointPrefix+'.amazonaws.com';
             s.basePath = '/';
             s['x-hasEquivalentPaths'] = false; // may get removed later


### PR DESCRIPTION
Very tiny simple PR, that I thought might be useful to totally separate from the other massive one.

This changes the externalDocs links from URLs like https://aws.amazon.com/s3/ to URLs like https://docs.aws.amazon.com/s3/, which are much more useful and docs-like (imo).

Note that both now and with this change, these URLs aren't correct for all services. There doesn't seem to be a system, e.g.:

* `acm-pca` endpoint docs are at https://docs.aws.amazon.com/acm/ and marketing is at https://aws.amazon.com/certificate-manager/
* `resource-groups` endpoint has no marketing page (afaict) and lives within https://docs.aws.amazon.com/systems-manager/.

This works for most of them though, especially the popular cases. Might be nice to improve in future, ok for now imo.